### PR TITLE
Credit Neil Kandalgaonkar in the copyright header of {emitter,parser}.js

### DIFF
--- a/src/jquery.i18n.emitter.js
+++ b/src/jquery.i18n.emitter.js
@@ -1,7 +1,7 @@
 /**
  * jQuery Internationalization library
  *
- * Copyright (C) 2012 Santhosh Thottingal
+ * Copyright (C) 2011-2013 Santhosh Thottingal, Neil Kandalgaonkar
  *
  * jquery.i18n is dual licensed GPLv2 or later and MIT. You don't have to do
  * anything special to choose one license or the other and you don't have to

--- a/src/jquery.i18n.parser.js
+++ b/src/jquery.i18n.parser.js
@@ -1,7 +1,7 @@
 /**
  * jQuery Internationalization library
  *
- * Copyright (C) 2012 Santhosh Thottingal
+ * Copyright (C) 2011-2013 Santhosh Thottingal, Neil Kandalgaonkar
  *
  * jquery.i18n is dual licensed GPLv2 or later and MIT. You don't have to do
  * anything special to choose one license or the other and you don't have to


### PR DESCRIPTION
He's already listed as a contributor in package.json, but I think
that's a bit thin considering about half the code in those files is
still exactly the way Neil originally wrote it.
