### PR TITLE
specified locale wasn't loading when dir was used in load()

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -142,6 +142,8 @@
 			if ( typeof source === 'string'	&&
 				source.split('.').pop() !== 'json'
 			) {
+				// Load specified locale then check for fallbacks when directory is specified in load()
+				sourceMap[locale] = source + '/' + locale + '.json';
 				fallbackLocales = ( $.i18n.fallbacks[locale] || [] )
 					.concat( this.options.fallbackLocale );
 				for ( locIndex in fallbackLocales ) {


### PR DESCRIPTION
I was trying to load a directory of translation messages, but the specified locale would not load, because the program only loads the fallbacks.  Here is an example of the code that I was using:

```
 i18n.load('/i18n', i18n.locale).done(
      function() {
           $('[data-i18n]').each(function(index) {
                $(this).i18n();
                $(this).html($.i18n($(this).attr('data-i18n')));
           } );
      } );
```

If the locale was set to "fr" and the "fr.json" existed, the program would not load this file and instead simply default back to "en.json".
