### PR TITLE
Repair support for IE8

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,7 @@
 	"undef": true,
 	"unused": true,
 	"strict": false,
+	"es3": true,
 
 	// Relaxing
 	"es5": false,

--- a/src/jquery.i18n.language.js
+++ b/src/jquery.i18n.language.js
@@ -467,7 +467,7 @@
 	};
 
 	$.extend( $.i18n.languages, {
-		/* default is a reserved eeyword breaking IE8 */
+		/* default is a reserved keyword breaking IE8 */
 		'default': language
 	} );
 }( jQuery ) );

--- a/src/jquery.i18n.language.js
+++ b/src/jquery.i18n.language.js
@@ -467,6 +467,7 @@
 	};
 
 	$.extend( $.i18n.languages, {
-		default: language
+		/* default is a reserved eeyword breaking IE8 */
+		'default': language
 	} );
 }( jQuery ) );


### PR DESCRIPTION
IE8 JS parser dies on ES3 reserved keywords like default being used as
object keys. This fixes it again. Also leave a comment and adapt the
.jshintrc file to check for es3 compatibility.

Follows-up 71c4219e72.

Relates to: https://phabricator.wikimedia.org/T118242