### PR TITLE
build: Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.8
+  - '0.10'
 before_script:
-  - "git submodule update --init"
+  - 'git submodule update --init'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "qunit": "0.7.6",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
-    "grunt-contrib-jshint": "0.11.2",
+    "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-connect": "0.10.1",
     "grunt-contrib-qunit": "0.7.0",
     "grunt-contrib-watch": "0.6.1",


### PR DESCRIPTION
* Use containers (triggered by 'sudo: false') so that builds start faster.
* Use Node 0.10 since we use dev dependencies that make use of '^' syntax
  in package.json, which is not supported in the npm version that ships
  with Node 0.8.