### PR TITLE
build: Update grunt-jscs from 1.8.0 to 2.7.0

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,5 @@
 {
-	"preset": "wikimedia"
+	"preset": "wikimedia",
+	"requireSpacesInsideBrackets": null,
+	"jsDoc": null
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-connect": "0.10.1",
     "grunt-contrib-qunit": "0.7.0",
     "grunt-contrib-watch": "0.6.1",
-    "grunt-jscs": "1.8.0"
+    "grunt-jscs": "2.7.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Failing rules `requireSpacesInsideBrackets` and `jsDoc` from the wikimedia preset have been temporarily disabled. I will upload patches for those when this one is merged.