### PR TITLE
build: Bump devDependencies to latest and make pass

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,7 @@
 	// Enforcing
 	"bitwise": true,
 	"eqeqeq": true,
-	"latedef": true,
+	"latedef": "nofunc",
 	"noarg": true,
 	"nonew": true,
 	"undef": true,

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "David Chan <david@troi.org>"
   ],
   "devDependencies": {
-    "qunit": "0.7.6",
-    "grunt": "0.4.5",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-jshint": "0.11.3",
-    "grunt-contrib-connect": "0.10.1",
-    "grunt-contrib-qunit": "0.7.0",
-    "grunt-contrib-watch": "0.6.1",
-    "grunt-jscs": "2.7.0"
+    "qunit": "0.9.1",
+    "grunt": "1.0.1",
+    "grunt-cli": "1.2.0",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-connect": "1.0.1",
+    "grunt-contrib-qunit": "1.2.0",
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-jscs": "2.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 qunit                    0.7.6  →  0.9.1
 grunt                    0.4.5  →  1.0.1
 grunt-cli               0.1.13  →  1.2.0
 grunt-contrib-jshint    0.11.3  →  1.0.0
 grunt-contrib-connect   0.10.1  →  1.0.1
 grunt-contrib-qunit      0.7.0  →  1.2.0
 grunt-contrib-watch      0.6.1  →  1.0.0
 grunt-jscs               2.7.0  →  2.8.0