### PR TITLE
Add capability to set attributes and raw HTML

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -234,10 +234,23 @@
 		String.locale = i18n.locale;
 		return this.each( function () {
 			var $this = $( this ),
-				messageKey = $this.data( 'i18n' );
+				messageKey = $this.data( 'i18n' ),
+				lBracket, rBracket, type, key;
 
 			if ( messageKey ) {
-				$this.text( i18n.parse( messageKey ) );
+				lBracket = messageKey.indexOf( '[' );
+				rBracket = messageKey.indexOf( ']' );
+				if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
+					type = messageKey.substring( lBracket + 1, rBracket );
+					key = messageKey.substr( rBracket + 1 );
+					if ( type === 'html' ) {
+						$this.html( i18n.parse( key ) );
+					} else {
+						$this.attr( type, i18n.parse( key ) );
+					}
+				} else {
+					$this.text( i18n.parse( messageKey ) );
+				}
 			} else {
 				$this.find( '[data-i18n]' ).i18n();
 			}

--- a/test/jquery.i18n.test.js
+++ b/test/jquery.i18n.test.js
@@ -23,6 +23,30 @@
 		assert.strictEqual( $fixture.i18n().text(), 'X', 'Content of fixture localized' );
 	} );
 
+	QUnit.test( 'Message parse HTML', 2, function ( assert ) {
+		var i18n = $( document ).data( 'i18n' ),
+			$fixture = $( '#qunit-fixture' );
+		// Load messages for localex
+		i18n.load( {
+			x: 'X<i>Y</i>',
+		}, 'localex' );
+		$fixture.data( 'i18n', 'x' );
+		assert.strictEqual( $fixture.i18n().html(), 'X&lt;i&gt;Y&lt;/i&gt;', 'Content of fixture localized with HTML encoded' );
+		$fixture.data( 'i18n', '[html]x' );
+		assert.strictEqual( $fixture.i18n().html(), 'X<i>Y</i>', 'Content of fixture localized with HTML as is' );
+	} );
+
+	QUnit.test( 'Message parse attrbutes', 1, function ( assert ) {
+		var i18n = $( document ).data( 'i18n' ),
+			$fixture = $( '#qunit-fixture' );
+		// Load messages for localex
+		i18n.load( {
+			x: 'title X',
+		}, 'localex' );
+		$fixture.data( 'i18n', '[title]x' );
+		assert.strictEqual( $fixture.i18n().attr( 'title' ), 'title X', 'Content of title attribute localized' );
+	} );
+
 	QUnit.module( 'jquery.i18n', {
 		setup: function () {
 			$.i18n( {


### PR DESCRIPTION
This patch adds special syntax (borrowed from jquery.i18next) that allows to use unencoded HTML and set localized attributes to tags using data-i18n. 

The usage is as follows:
* Key `[html]key` - use unencoded HTML for this key
* Key `[attr]key` - set attribute attr instead of text content