### PR TITLE
Use String#slice instead of String#substr or String#substring

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -241,8 +241,8 @@
 				lBracket = messageKey.indexOf( '[' );
 				rBracket = messageKey.indexOf( ']' );
 				if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
-					type = messageKey.substring( lBracket + 1, rBracket );
-					key = messageKey.substr( rBracket + 1 );
+					type = messageKey.slice( lBracket + 1, rBracket );
+					key = messageKey.slice( rBracket + 1 );
 					if ( type === 'html' ) {
 						$this.html( i18n.parse( key ) );
 					} else {

--- a/src/jquery.i18n.language.js
+++ b/src/jquery.i18n.language.js
@@ -287,9 +287,9 @@
 			for ( index = 0; index < forms.length; index++ ) {
 				form = forms[ index ];
 				if ( explicitPluralPattern.test( form ) ) {
-					formCount = parseInt( form.substring( 0, form.indexOf( '=' ) ), 10 );
+					formCount = parseInt( form.slice( 0, form.indexOf( '=' ) ), 10 );
 					if ( formCount === count ) {
-						return ( form.substr( form.indexOf( '=' ) + 1 ) );
+						return ( form.slice( form.indexOf( '=' ) + 1 ) );
 					}
 					forms[ index ] = undefined;
 				}

--- a/src/jquery.i18n.parser.js
+++ b/src/jquery.i18n.parser.js
@@ -123,7 +123,7 @@
 				return function () {
 					var result = null;
 
-					if ( message.substr( pos, len ) === s ) {
+					if ( message.slice( pos, pos + len ) === s ) {
 						result = s;
 						pos += len;
 					}
@@ -134,7 +134,7 @@
 
 			function makeRegexParser( regex ) {
 				return function () {
-					var matches = message.substr( pos ).match( regex );
+					var matches = message.slice( pos ).match( regex );
 
 					if ( matches === null ) {
 						return null;

--- a/src/languages/fi.js
+++ b/src/languages/fi.js
@@ -33,7 +33,7 @@
 				break;
 			case 'illative':
 				// Double the last letter and add 'n'
-				word += word.substr( word.length - 1 ) + 'n';
+				word += word.slice( -1 ) + 'n';
 				break;
 			case 'inessive':
 				word += ( aou ? 'ssa' : 'ssä' );

--- a/src/languages/he.js
+++ b/src/languages/he.js
@@ -10,17 +10,17 @@
 			case 'prefixed':
 			case 'תחילית': // the same word in Hebrew
 				// Duplicate prefixed "Waw", but only if it's not already double
-				if ( word.substr( 0, 1 ) === 'ו' && word.substr( 0, 2 ) !== 'וו' ) {
+				if ( word.slice( 0, 1 ) === 'ו' && word.slice( 0, 2 ) !== 'וו' ) {
 					word = 'ו' + word;
 				}
 
 				// Remove the "He" if prefixed
-				if ( word.substr( 0, 1 ) === 'ה' ) {
-					word = word.substr( 1, word.length );
+				if ( word.slice( 0, 1 ) === 'ה' ) {
+					word = word.slice( 1 );
 				}
 
 				// Add a hyphen (maqaf) before numbers and non-Hebrew letters
-				if ( word.substr( 0, 1 ) < 'א' || word.substr( 0, 1 ) > 'ת' ) {
+				if ( word.slice( 0, 1 ) < 'א' || word.slice( 0, 1 ) > 'ת' ) {
 					word = '־' + word;
 				}
 			}

--- a/src/languages/hy.js
+++ b/src/languages/hy.js
@@ -8,12 +8,12 @@
 	$.i18n.languages.hy = $.extend( {}, $.i18n.languages[ 'default' ], {
 		convertGrammar: function ( word, form ) {
 			if ( form === 'genitive' ) { // սեռական հոլով
-				if ( word.substr( -1 ) === 'ա' ) {
-					word = word.substr( 0, word.length - 1 ) + 'այի';
-				} else if ( word.substr( -1 ) === 'ո' ) {
-					word = word.substr( 0, word.length - 1 ) + 'ոյի';
-				} else if ( word.substr( -4 ) === 'գիրք' ) {
-					word = word.substr( 0, word.length - 4 ) + 'գրքի';
+				if ( word.slice( -1 ) === 'ա' ) {
+					word = word.slice( 0, -1 ) + 'այի';
+				} else if ( word.slice( -1 ) === 'ո' ) {
+					word = word.slice( 0, -1 ) + 'ոյի';
+				} else if ( word.slice( -4 ) === 'գիրք' ) {
+					word = word.slice( 0, -4 ) + 'գրքի';
 				} else {
 					word = word + 'ի';
 				}

--- a/src/languages/ml.js
+++ b/src/languages/ml.js
@@ -13,34 +13,34 @@
 			switch ( form ) {
 				case 'ഉദ്ദേശിക':
 				case 'dative':
-					if ( word.substr( -1 ) === 'ു' ||
-						word.substr( -1 ) === 'ൂ' ||
-						word.substr( -1 ) === 'ൗ' ||
-						word.substr( -1 ) === 'ൌ'
+					if ( word.slice( -1 ) === 'ു' ||
+						word.slice( -1 ) === 'ൂ' ||
+						word.slice( -1 ) === 'ൗ' ||
+						word.slice( -1 ) === 'ൌ'
 					) {
 						word += 'വിന്';
-					} else if ( word.substr( -1 ) === 'ം' ) {
-						word = word.substr( 0, word.length - 1 ) + 'ത്തിന്';
-					} else if ( word.substr( -1 ) === 'ൻ' ) {
+					} else if ( word.slice( -1 ) === 'ം' ) {
+						word = word.slice( 0, -1 ) + 'ത്തിന്';
+					} else if ( word.slice( -1 ) === 'ൻ' ) {
 						// Atomic chillu n. അവൻ -> അവന്
-						word = word.substr( 0, word.length - 1 ) + 'ന്';
-					} else if ( word.substr( -3 ) === 'ന്\u200d' ) {
+						word = word.slice( 0, -1 ) + 'ന്';
+					} else if ( word.slice( -3 ) === 'ന്\u200d' ) {
 						// chillu n. അവൻ -> അവന്
-						word = word.substr( 0, word.length - 1 );
-					} else if ( word.substr( -1 ) === 'ൾ' || word.substr( -3 ) === 'ള്\u200d' ) {
+						word = word.slice( 0, -1 );
+					} else if ( word.slice( -1 ) === 'ൾ' || word.slice( -3 ) === 'ള്\u200d' ) {
 						word += 'ക്ക്';
-					} else if ( word.substr( -1 ) === 'ർ' || word.substr( -3 ) === 'ര്\u200d' ) {
+					} else if ( word.slice( -1 ) === 'ർ' || word.slice( -3 ) === 'ര്\u200d' ) {
 						word += 'ക്ക്';
-					} else if ( word.substr( -1 ) === 'ൽ' ) {
+					} else if ( word.slice( -1 ) === 'ൽ' ) {
 						// Atomic chillu ൽ , ഫയൽ -> ഫയലിന്
-						word = word.substr( 0, word.length - 1 ) + 'ലിന്';
-					} else if ( word.substr( -3 ) === 'ല്\u200d' ) {
+						word = word.slice( 0, -1 ) + 'ലിന്';
+					} else if ( word.slice( -3 ) === 'ല്\u200d' ) {
 						// chillu ല്\u200d , ഫയല്\u200d -> ഫയലിന്
-						word = word.substr( 0, word.length - 2 ) + 'ിന്';
-					} else if ( word.substr( -2 ) === 'ു്' ) {
-						word = word.substr( 0, word.length - 2 ) + 'ിന്';
-					} else if ( word.substr( -1 ) === '്' ) {
-						word = word.substr( 0, word.length - 1 ) + 'ിന്';
+						word = word.slice( 0, -2 ) + 'ിന്';
+					} else if ( word.slice( -2 ) === 'ു്' ) {
+						word = word.slice( 0, -2 ) + 'ിന്';
+					} else if ( word.slice( -1 ) === '്' ) {
+						word = word.slice( 0, -1 ) + 'ിന്';
 					} else {
 						// കാവ്യ -> കാവ്യയ്ക്ക്, ഹരി -> ഹരിയ്ക്ക്, മല -> മലയ്ക്ക്
 						word += 'യ്ക്ക്';
@@ -49,42 +49,42 @@
 					break;
 				case 'സംബന്ധിക':
 				case 'genitive':
-					if ( word.substr( -1 ) === 'ം' ) {
-						word = word.substr( 0, word.length - 1 ) + 'ത്തിന്റെ';
-					} else if ( word.substr( -2 ) === 'ു്' ) {
-						word = word.substr( 0, word.length - 2 ) + 'ിന്റെ';
-					} else if ( word.substr( -1 ) === '്' ) {
-						word = word.substr( 0, word.length - 1 ) + 'ിന്റെ';
-					} else if (  word.substr( -1 ) === 'ു' ||
-						word.substr( -1 ) === 'ൂ' ||
-						word.substr( -1 ) === 'ൗ' ||
-						word.substr( -1 ) === 'ൌ'
+					if ( word.slice( -1 ) === 'ം' ) {
+						word = word.slice( 0, -1 ) + 'ത്തിന്റെ';
+					} else if ( word.slice( -2 ) === 'ു്' ) {
+						word = word.slice( 0, -2 ) + 'ിന്റെ';
+					} else if ( word.slice( -1 ) === '്' ) {
+						word = word.slice( 0, -1 ) + 'ിന്റെ';
+					} else if (  word.slice( -1 ) === 'ു' ||
+						word.slice( -1 ) === 'ൂ' ||
+						word.slice( -1 ) === 'ൗ' ||
+						word.slice( -1 ) === 'ൌ'
 					) {
 						word += 'വിന്റെ';
-					} else if ( word.substr( -1 ) === 'ൻ' ) {
+					} else if ( word.slice( -1 ) === 'ൻ' ) {
 						// Atomic chillu n. അവൻ -> അവന്റെ
-						word = word.substr( 0, word.length - 1 ) + 'ന്റെ';
-					} else if ( word.substr( -3 ) === 'ന്\u200d' ) {
+						word = word.slice( 0, -1 ) + 'ന്റെ';
+					} else if ( word.slice( -3 ) === 'ന്\u200d' ) {
 						// chillu n. അവൻ -> അവന്റെ
-						word = word.substr( 0, word.length - 1 ) + 'റെ';
-					} else if ( word.substr( -3 ) === 'ള്\u200d' ) {
+						word = word.slice( 0, -1 ) + 'റെ';
+					} else if ( word.slice( -3 ) === 'ള്\u200d' ) {
 						// chillu n. അവൾ -> അവളുടെ
-						word = word.substr( 0, word.length - 2 ) + 'ുടെ';
-					} else if ( word.substr( -1 ) === 'ൾ' ) {
+						word = word.slice( 0, -2 ) + 'ുടെ';
+					} else if ( word.slice( -1 ) === 'ൾ' ) {
 						// Atomic chillu n. അവള്\u200d -> അവളുടെ
-						word = word.substr( 0, word.length - 1 ) + 'ളുടെ';
-					} else if ( word.substr( -1 ) === 'ൽ' ) {
+						word = word.slice( 0, -1 ) + 'ളുടെ';
+					} else if ( word.slice( -1 ) === 'ൽ' ) {
 						// Atomic l. മുയല്\u200d -> മുയലിന്റെ
-						word = word.substr( 0, word.length - 1 ) + 'ലിന്റെ';
-					} else if ( word.substr( -3 ) === 'ല്\u200d' ) {
+						word = word.slice( 0, -1 ) + 'ലിന്റെ';
+					} else if ( word.slice( -3 ) === 'ല്\u200d' ) {
 						// chillu l. മുയല്\u200d -> അവളുടെ
-						word = word.substr( 0, word.length - 2 ) + 'ിന്റെ';
-					} else if ( word.substr( -3 ) === 'ര്\u200d' ) {
+						word = word.slice( 0, -2 ) + 'ിന്റെ';
+					} else if ( word.slice( -3 ) === 'ര്\u200d' ) {
 						// chillu r. അവര്\u200d -> അവരുടെ
-						word = word.substr( 0, word.length - 2 ) + 'ുടെ';
-					} else if ( word.substr( -1 ) === 'ർ' ) {
+						word = word.slice( 0, -2 ) + 'ുടെ';
+					} else if ( word.slice( -1 ) === 'ർ' ) {
 						// Atomic chillu r. അവർ -> അവരുടെ
-						word = word.substr( 0, word.length - 1 ) + 'രുടെ';
+						word = word.slice( 0, -1 ) + 'രുടെ';
 					} else {
 						word += 'യുടെ';
 					}

--- a/src/languages/os.js
+++ b/src/languages/os.js
@@ -22,7 +22,7 @@
 
 			if ( word.match( /тæ$/i ) ) {
 				// Checking if the $word is in plural form
-				word = word.substring( 0, word.length - 1 );
+				word = word.slice( 0, -1 );
 				endAllative = 'æм';
 			} else if ( word.match( /[аæеёиоыэюя]$/i ) ) {
 				// Works if word is in singular form.
@@ -34,7 +34,7 @@
 				// vowel 'U' in cyrillic Ossetic.
 				// Examples: {{grammar:genitive|аунеу}} = аунеуы,
 				// {{grammar:genitive|лæппу}} = лæппуйы.
-				if ( !word.substring( word.length - 2, word.length - 1 )
+				if ( !word.slice( -2, -1 )
 						.match( /[аæеёиоыэюя]$/i ) ) {
 					jot = 'й';
 				}

--- a/src/languages/ru.js
+++ b/src/languages/ru.js
@@ -8,18 +8,18 @@
 	$.i18n.languages.ru = $.extend( {}, $.i18n.languages[ 'default' ], {
 		convertGrammar: function ( word, form ) {
 			if ( form === 'genitive' ) { // родительный падеж
-				if ( word.substr( -1 ) === 'ь' ) {
-					word = word.substr( 0, word.length - 1 ) + 'я';
-				} else if ( word.substr( -2 ) === 'ия' ) {
-					word = word.substr( 0, word.length - 2 ) + 'ии';
-				} else if ( word.substr( -2 ) === 'ка' ) {
-					word = word.substr( 0, word.length - 2 ) + 'ки';
-				} else if ( word.substr( -2 ) === 'ти' ) {
-					word = word.substr( 0, word.length - 2 ) + 'тей';
-				} else if ( word.substr( -2 ) === 'ды' ) {
-					word = word.substr( 0, word.length - 2 ) + 'дов';
-				} else if ( word.substr( -3 ) === 'ник' ) {
-					word = word.substr( 0, word.length - 3 ) + 'ника';
+				if ( word.slice( -1 ) === 'ь' ) {
+					word = word.slice( 0, -1 ) + 'я';
+				} else if ( word.slice( -2 ) === 'ия' ) {
+					word = word.slice( 0, -2 ) + 'ии';
+				} else if ( word.slice( -2 ) === 'ка' ) {
+					word = word.slice( 0, -2 ) + 'ки';
+				} else if ( word.slice( -2 ) === 'ти' ) {
+					word = word.slice( 0, -2 ) + 'тей';
+				} else if ( word.slice( -2 ) === 'ды' ) {
+					word = word.slice( 0, -2 ) + 'дов';
+				} else if ( word.slice( -3 ) === 'ник' ) {
+					word = word.slice( 0, -3 ) + 'ника';
 				}
 			}
 

--- a/src/languages/uk.js
+++ b/src/languages/uk.js
@@ -9,24 +9,24 @@
 		convertGrammar: function ( word, form ) {
 			switch ( form ) {
 			case 'genitive': // родовий відмінок
-				if ( word.substr( -1 ) === 'ь' ) {
-					word = word.substr( 0, word.length - 1 ) + 'я';
-				} else if ( word.substr( -2 ) === 'ія' ) {
-					word = word.substr( 0, word.length - 2 ) + 'ії';
-				} else if ( word.substr( -2 ) === 'ка' ) {
-					word = word.substr( 0, word.length - 2 ) + 'ки';
-				} else if ( word.substr( -2 ) === 'ти' ) {
-					word = word.substr( 0, word.length - 2 ) + 'тей';
-				} else if ( word.substr( -2 ) === 'ды' ) {
-					word = word.substr( 0, word.length - 2 ) + 'дов';
-				} else if ( word.substr( -3 ) === 'ник' ) {
-					word = word.substr( 0, word.length - 3 ) + 'ника';
+				if ( word.slice( -1 ) === 'ь' ) {
+					word = word.slice( 0, -1 ) + 'я';
+				} else if ( word.slice( -2 ) === 'ія' ) {
+					word = word.slice( 0, -2 ) + 'ії';
+				} else if ( word.slice( -2 ) === 'ка' ) {
+					word = word.slice( 0, -2 ) + 'ки';
+				} else if ( word.slice( -2 ) === 'ти' ) {
+					word = word.slice( 0, -2 ) + 'тей';
+				} else if ( word.slice( -2 ) === 'ды' ) {
+					word = word.slice( 0, -2 ) + 'дов';
+				} else if ( word.slice( -3 ) === 'ник' ) {
+					word = word.slice( 0, -3 ) + 'ника';
 				}
 
 				break;
 			case 'accusative': // знахідний відмінок
-				if ( word.substr( -2 ) === 'ія' ) {
-					word = word.substr( 0, word.length - 2 ) + 'ію';
+				if ( word.slice( -2 ) === 'ія' ) {
+					word = word.slice( 0, -2 ) + 'ію';
 				}
 
 				break;


### PR DESCRIPTION
Reasons:

* Using three similar methods is confusing since they behave
  differently. Using just one makes code easier to understand
  and less error-prone.
* `substr()` is part of ECMAScript Annex B (discouraged for new code,
  not part of the core language and not portable for use outside
  web browsers).
* `substr()` takes `(start, length)`, `substring()` and `slice()` on
  the other hand take `(start, end)`.
* `substr()` is buggy in IE < 9.
* `substring()` doesn't support negative index.
* `slice()` is consistent with Array#slice, matches behaviour
  of popular sub-string methods in other languages (e.g. PHP substr),
  and has an optional second parameter. This helps avoid needless
  calculation of string length.

See also:
* https://github.com/wikimedia/mediawiki/commit/c7181834
  (https://gerrit.wikimedia.org/r/158108)
* https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript#Pitfalls
