### PR TITLE
build: Remove unused 'pkg' property in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,6 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-jscs' );
 
 	grunt.initConfig( {
-		pkg: grunt.file.readJSON( 'package.json' ),
 		connect: {
 			server: {
 				options: {


### PR DESCRIPTION
Unused, most likely copied from another repo.