### PR TITLE
Allow to use "?" symbols in lang file URLs

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -143,7 +143,7 @@
 				locale = $.i18n().locale;
 			}
 			if ( typeof source === 'string' &&
-				source.split( '.' ).pop() !== 'json'
+				source.split( '?' )[0].split( '.' ).pop() !== 'json'
 			) {
 				// Load specified locale then check for fallbacks when directory is specified in load()
 				sourceMap[ locale ] = source + '/' + locale + '.json';


### PR DESCRIPTION
When updating some app's version, it's a good idea to force browser use newest language files also. Simplest way of doing it (for me) is adding '?v=VERSION' string to original URL.