### PR TITLE
Use SPDX 3.0 license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "engine": {
     "node": ">=4.0.0"
   },
-  "license": "(MIT OR GPL-2.0+)",
+  "license": "(MIT OR GPL-2.0-or-later)",
   "scripts": {
     "test": "grunt test --verbose"
   }


### PR DESCRIPTION
SPDX released version 3 of their license list (<https://spdx.org/licenses/>),
which changed the FSF licenses to explicitly end in -only or -or-later
instead of relying on an easy to miss + symbol.