### PR TITLE
build: Add a .mailmap file so that `git shortlog` is cleaner

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Abhishek Hingnikar <djdark88.7@gmail.com>
+Aleksandr Zykov <alexandrz@gmail.com>
+Amir E. Aharoni <amir.aharoni@mail.huji.ac.il>
+Andre Klapper <a9016009@gmx.de>
+David Chan <david@troi.org>
+David Pollack <david@da3.net>
+Derk-Jan Hartman <hartman@videolan.org>
+Derk-Jan Hartman <hartman@videolan.org> <hartman.wiki@gmail.com>
+James D. Forrester <jforrester@wikimedia.org>
+James D. Forrester <jforrester@wikimedia.org> <github@jdforrester.org>
+Jishnu Mohan <jishnu7@gmail.com>
+Kartik Mistry <kartik.mistry@gmail.com>
+Kunal Mehta <legoktm@member.fsf.org>
+Kunal Mehta <legoktm@member.fsf.org> <kunalm@legoktm.com>
+Kunal Mehta <legoktm@member.fsf.org> <legoktm@gmail.com>
+ldittmar <ldittmar.privat@gmail.com>
+Mathieu BODIN <mathieubodin@icloud.com>
+Niklas Laxström <niklas.laxstrom@gmail.com>
+Přemysl Václav Duben <PreVaDu@users.noreply.github.com>
+Ricordisamoa <ricordisamoa@openmailbox.org>
+Roan Kattouw <roan.kattouw@gmail.com>
+Santhosh Thottingal <santhosh.thottingal@gmail.com>
+Siebrand Mazeland <s.mazeland@xs4all.nl>
+soulmare <32684597+soulmare@users.noreply.github.com>
+Stanislav Malyshev <smalyshev@gmail.com>
+Timo Tijhof <krinklemail@gmail.com>
+Yaron Shahrabani <sh.yaron@gmail.com>


### PR DESCRIPTION
Where appropriate, using the form and e-mail the commiter has in
MediaWiki's .mailmap file.