### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ It is possible to switch to another locale after plugin is initialized. See belo
 $.i18n({
     locale: 'he' // Locale is Hebrew
 });
-$.i18n( 'message_hello' ); // This will give the Hebrew translation of message key `message_hello`.
+$.i18n( 'message-hello' ); // This will give the Hebrew translation of message key `message-hello`.
 $.i18n().locale = 'ml'; // Now onwards locale is 'Malayalam'
-$.i18n( 'message_hello' ); // This will give the Malayalam translation of message key `message_hello`.
+$.i18n( 'message-hello' ); // This will give the Malayalam translation of message key `message-hello`.
 ```
 
 ## Message Loading
@@ -230,8 +230,8 @@ It is also possible to refer messages from an external URL. See below example
 ```javascript
 $.i18n().load( {
 	en: {
-		message_hello: 'Hello World',
-		message_welcome: 'Welcome'
+		message-hello: 'Hello World',
+		message-welcome: 'Welcome'
 	},
 	hi: 'i18n/messages-hi.json', // Messages for Hindi
 	de: 'i18n/messages-de.json'
@@ -243,18 +243,18 @@ Messages for a locale can be also loaded in parts. Example
 ```javascript
 $.i18n().load( {
 	en: {
-		message_hello: 'Hello World',
-		message_welcome: 'Welcome'
+		message-hello: 'Hello World',
+		message-welcome: 'Welcome'
 	}
 } );
 
 $.i18n().load( {
     	// This does not remove the previous messages.
 	en: {
-		'message_header' : 'Header',
-		'message_footer' : 'Footer',
-		// This will overwrite message_welcome message
-		'message_welcome' : 'Welcome back'
+		'message-header' : 'Header',
+		'message-footer' : 'Footer',
+		// This will overwrite message-welcome message
+		'message-welcome' : 'Welcome back'
 	}
 } );
 ```

--- a/README.md
+++ b/README.md
@@ -294,7 +294,10 @@ It is also possible to have the above li node with fallback text already in plac
 The framework will place the localized message corresponding to message-key as the text value of the node. Similar to $('selector').i18n( ... ).
 This will not work for dynamically created elements.
 
-Note that if data-i18n contains html markup, that html will not be used as the element content, instead, the text version will be used. $.fn.i18n is always about replacing text of the element. If you want to change the html of the element, you may want to use: ```$(selector).html($.i18n(messagekey))```
+Note that if data-i18n contains html markup, that html will not be used as the element content, instead, the text version will be used. But if the message key is prefixed with `[html]`, the element's html will be changed. For example ```<li data-i18n="[html]message-key">Fallback html</li>```, in this if the message-key has a value containing HTML markup, the `<li>` tags html will be replaced by that html.
+
+
+If you want to change the html of the element, you can also use: ```$(selector).html($.i18n(messagekey))```
 
 Examples
 ========


### PR DESCRIPTION
Addresses #169 

1. Doc: Use dashes in message keys instead of underscores 
2. Add documentation for the [html] prefix for HTML message value 