### PR TITLE
Remove conditional 'navigator' use

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -251,15 +251,9 @@
 	};
 
 	function getDefaultLocale() {
-		var nav, locale = $( 'html' ).attr( 'lang' );
-
+		var locale = $( 'html' ).attr( 'lang' );
 		if ( !locale ) {
-			if ( typeof window.navigator !== undefined ) {
-				nav = window.navigator;
-				locale = nav.language || nav.userLanguage || '';
-			} else {
-				locale = '';
-			}
+			locale = navigator.language || navigator.userLanguage || '';
 		}
 		return locale;
 	}


### PR DESCRIPTION
This has been present since the first commit, and I do not know why.

This is a standard part of the browser and should not need a conditional,
and it also does not need a window-proxy. (It's a whitelisted global
in eslint).