### PR TITLE
make possible to work with fallbackLocale different from 'en'

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -62,7 +62,7 @@
 					localePartIndex--;
 				} while ( localePartIndex );
 
-				if ( locale === 'en' ) {
+				if ( locale === this.options.fallbackLocale ) {
 					break;
 				}
 


### PR DESCRIPTION
Fix bug: if you set a fallbackLocale different to 'en' - fallbacks doesn't work for 'en'

Example:
```
//en.json
{
}
```
```
//ru.json
{
   "testKey" "тест"
}
```
```
//index.js
$.i18n({
  locale: 'en',
  fallbacks: {
    'en': ['ru']
  },
  fallbackLocale: 'ru'
});
$.i18n().load({
    ru: 'ru.json'
    en: 'en.json'
});

console.log($.i18n("testKey")); //testKey but expected тест
```