### PR TITLE
Dependency updates 2019 may

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   "devDependencies": {
     "eslint-config-wikimedia": "0.7.2",
     "eslint-plugin-qunit": "3.3.1",
-    "grunt": "1.0.3",
+    "grunt": "^1.0.4",
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-qunit": "2.0.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "21.0.0",
-    "jquery": "3.2.1",
-    "qunit": "2.6.1"
+    "jquery": "3.4.1",
+    "qunit": "^2.9.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fixes npm security warning about jquery version - https://nvd.nist.gov/vuln/detail/CVE-2019-11358
* Also update npm package dependencies using npm update
* CLDRPluralRuleParser submodule update to 1.3.2(c57cff2bd18830d7fce5bbdd4461204d422e8d9a)


This is probably the last update to this since we are going to replace this with the [banana](https://github.com/santhoshtr/jquery.i18n/tree/banana) branch that uses banana-i18n which is getting ready
