### PR TITLE
Proposed some grammatical fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To run tests locally, run `npm test`, and this will run the tests.
 Message File Format
 ===================
 
-The message files are json formatted. As a convention you can have a folder named i18n inside your source code. For each language or locale, have a file named like languagecode.json.
+The message files are json formatted. As a convention, you can have a folder named i18n inside your source code. For each language or locale, have a file named like languagecode.json.
 
 Example:
 ```
@@ -88,7 +88,7 @@ A simple en.json file example is given below
 
 The json file should be a valid json. The ```@metadata``` holds all kind of data that are not messages. You can store author information, copyright, updated date or anything there.
 
-Messages are key value pairs. It is a good convention to prefix your appname to message keys to make the messages unique. It acts as the namespace for the message keys. It is also a good convention to have the message keys with ```-``` separated words, all in lower case.
+Messages are key-value pairs. It is a good convention to prefix your appname to message keys to make the messages unique. It acts as the namespace for the message keys. It is also a good convention to have the message keys with ```-``` separated words, all in lower case.
 
 If you are curious to see some real jquery.i18n message file from other projects:
 
@@ -97,7 +97,7 @@ If you are curious to see some real jquery.i18n message file from other projects
 
 Single message file for all languages
 -------------------------------------
-There are some alternate message file format supported for different use cases. If your application is not big, and want all the translation in a single file, you can have it as shown in the below example:
+There are some alternate message file formats supported for different use cases. If your application is not big, and want all the translation in a single file, you can have it as shown in the below example:
 
 ```json
 {
@@ -129,7 +129,7 @@ There are some alternate message file format supported for different use cases. 
 }
 ```
 
-Here the json file contains language code as key value and messagekey-message pairs as the value for all language pairs. You can choose this format or per-language file formats depending on your use case. Per-language files are more convenient for collaboration, version controlling, scalability, etc.
+Here the json file contains language code as key-value and messagekey-message pairs as the value for all language pairs. You can choose this format or per-language file formats depending on your use case. Per-language files are more convenient for collaboration, version controlling, scalability, etc.
 
 In this approach, it is also possible to give a file name as the value of language code.
 
@@ -163,7 +163,7 @@ To translate the jquery.i18n application, depending on the expertise of the tran
 
 * Editing the json files directly - Suitable for translators with technical background. Also suitable if your application is small and you want to work with only a small number of languages
 * Providing a translation interface along with your application: Suitable for proprietary or private applications with significant amount of translators
-* Using open source translation platforms like translatewiki.net. The MediaWiki and jquery.uls from previous examples use translatewiki.net for crowdsourced message translation. Translatewiki.net can update your code repo in regular intervals with updated translations. Highly recommended if your application is opensource and want localized to as many as languages possible with maximum number of translators.
+* Using open source translation platforms like translatewiki.net. The MediaWiki and jquery.uls from previous examples use translatewiki.net for crowdsourced message translation. Translatewiki.net can update your code repo at regular intervals with updated translations. Highly recommended if your application is opensource and want it to be localized to as many as languages possible with maximum number of translators.
 
 Usage
 =====
@@ -184,7 +184,7 @@ In case locale option is not given, `jquery.i18n` plugin will use the language a
 <html lang="he" dir="rtl">
 ```
 
-In this case the locale will be he(Hebrew). If that `lang` attribute is also missing, it will try to use the locale specified by the browser.
+In this case, the locale will be he(Hebrew). If that `lang` attribute is also missing, it will try to use the locale specified by the browser.
 
 It is possible to switch to another locale after plugin is initialized. See below example:
 
@@ -336,8 +336,8 @@ In case of English, there are only 2 plural forms, but many languages use more t
 
 For example, English has 2 plural forms and the message format will look like `{{PLURAL:$1|one|other}}`. for Arabic there are 6 plural forms and format will look like `{{PLURAL:$1|zero|one|two|few|many|other}}`.
 
-You cannot skip a plural form from the middle or beginning. However you can skip from end. For example, in arabic, if the message is like
-`{{PLURAL:$1|A|B}}`, for 0, A will be used, for numbers that fall under one,two,few,many,other categories B will be used.
+You cannot skip a plural form from the middle or beginning. However, you can skip from end. For example, in Arabic, if the message is like
+`{{PLURAL:$1|A|B}}`, for 0, A will be used, for numbers that fall under one, two, few, many, other categories B will be used.
 
 If there is an explicit plural form to be given for a specific number, it is possible with the following syntax
 
@@ -348,7 +348,7 @@ $.i18n(message, 12 ); // Gives "Box has a dozen eggs."
 ```
 
 ## Gender
-Similar to plural, depending on gender of placeholders, mostly user names, the syntax changes dynamically. An example in English is "Alice changed her profile picture" and "Bob changed his profile picture". To support this {{GENDER...}} syntax can be used as show in example
+Similar to plural, depending on gender of placeholders, mostly user names, the syntax changes dynamically. An example in English is "Alice changed her profile picture" and "Bob changed his profile picture". To support this {{GENDER...}} syntax can be used as shown in example
 
 ```javascript
 var message = "$1 changed {{GENDER:$2|his|her}} profile picture";


### PR DESCRIPTION
<h1>Description</h1>

1. It looked as if comma was missing after the introductory phase '<strong>As a coonvention</strong>', so I have added comma after it.

2.  The '<strong>key value</strong>' was missing hyphen, hence I have corrected it by adding the hyphen.

3. <strong>format</strong> was changed to <strong>formats</strong> as <strong>are</strong> signifies plural.

4. <strong>in regular intervals</strong> was corrected as <strong>at regular intervals</strong>.

5. <strong>and want localized to</strong> was corrected to <strong>and want it to be localized to</strong>.

6. Comma was added after <strong>In this case</strong>.

7. Comma was added at several other required places too.

8. <strong>arabic</strong> is a proper noun, hence it was necessary for it to be capitalized. 

9. <strong>can be used as show in example</strong> was changed to <strong>can be used as shown in example</strongt>.
 