### PR TITLE
Adding support to multiple attribute replacements on the same element

### DIFF
--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -228,19 +228,29 @@
 		return this.each( function () {
 			var $this = $( this ),
 				messageKey = $this.data( 'i18n' ),
-				lBracket, rBracket, type, key;
+				lBracket, rBracket, type, key, messageKeyArray;
 
 			if ( messageKey ) {
 				lBracket = messageKey.indexOf( '[' );
-				rBracket = messageKey.indexOf( ']' );
-				if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
-					type = messageKey.slice( lBracket + 1, rBracket );
-					key = messageKey.slice( rBracket + 1 );
-					if ( type === 'html' ) {
-						$this.html( i18n.parse( key ) );
-					} else {
-						$this.attr( type, i18n.parse( key ) );
-					}
+				if ( lBracket !== -1 ) { // has any brackets, otherwise skip to perform better
+					messageKeyArray = messageKey.split( ';' );
+
+					messageKeyArray.forEach( function ( mk ) {
+						if ( mk !== '' ) {
+							lBracket = mk.indexOf( '[' );
+							rBracket = mk.indexOf( ']' );
+
+							if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
+								type = mk.slice( lBracket + 1, rBracket );
+								key = mk.slice( rBracket + 1 );
+								if ( type === 'html' ) {
+									$this.html( i18n.parse( key ) );
+								} else {
+									$this.attr( type, i18n.parse( key ) );
+								}
+							}
+						}
+					} );
 				} else {
 					$this.text( i18n.parse( messageKey ) );
 				}

--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -231,29 +231,26 @@
 				lBracket, rBracket, type, key, messageKeyArray;
 
 			if ( messageKey ) {
-				lBracket = messageKey.indexOf( '[' );
-				if ( lBracket !== -1 ) { // has any brackets, otherwise skip to perform better
-					messageKeyArray = messageKey.split( ';' );
+				messageKeyArray = messageKey.split( ';' );
 
-					messageKeyArray.forEach( function ( mk ) {
-						if ( mk !== '' ) {
-							lBracket = mk.indexOf( '[' );
-							rBracket = mk.indexOf( ']' );
+				messageKeyArray.forEach( function ( mk ) {
+					if ( mk !== '' ) {
+						lBracket = mk.indexOf( '[' );
+						rBracket = mk.indexOf( ']' );
 
-							if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
-								type = mk.slice( lBracket + 1, rBracket );
-								key = mk.slice( rBracket + 1 );
-								if ( type === 'html' ) {
-									$this.html( i18n.parse( key ) );
-								} else {
-									$this.attr( type, i18n.parse( key ) );
-								}
+						if ( lBracket !== -1 && rBracket !== -1 && lBracket < rBracket ) {
+							type = mk.slice( lBracket + 1, rBracket );
+							key = mk.slice( rBracket + 1 );
+							if ( type === 'html' ) {
+								$this.html( i18n.parse( key ) );
+							} else {
+								$this.attr( type, i18n.parse( key ) );
 							}
+						} else {
+							$this.text( i18n.parse( mk ) );
 						}
-					} );
-				} else {
-					$this.text( i18n.parse( messageKey ) );
-				}
+					}
+				} );
 			} else {
 				$this.find( '[data-i18n]' ).i18n();
 			}

--- a/test/jquery.i18n.test.js
+++ b/test/jquery.i18n.test.js
@@ -62,6 +62,19 @@
 		assert.strictEqual( $fixture.i18n().attr( 'custom' ), 'custom Y', 'Content of second attribute localized' );
 	} );
 
+	QUnit.test( 'Message parse multiple attributes, one setting text', function ( assert ) {
+		var i18n = $( document ).data( 'i18n' ),
+			$fixture = $( '#qunit-fixture' );
+		// Load messages for localex
+		i18n.load( {
+			x: 'title X',
+			y: 'text y'
+		}, 'localex' );
+		$fixture.data( 'i18n', '[title]x;y' );
+		assert.strictEqual( $fixture.i18n().attr( 'title' ), 'title X', 'Content of first attribute localized' );
+		assert.strictEqual( $fixture.i18n().text(), 'text y', 'Content of fixture localized' );
+	} );
+
 	QUnit.module( 'jquery.i18n', {
 		beforeEach: function () {
 			$.i18n( {

--- a/test/jquery.i18n.test.js
+++ b/test/jquery.i18n.test.js
@@ -49,6 +49,19 @@
 		assert.strictEqual( $fixture.i18n().attr( 'title' ), 'title X', 'Content of title attribute localized' );
 	} );
 
+	QUnit.test( 'Message parse multiple attributes', function ( assert ) {
+		var i18n = $( document ).data( 'i18n' ),
+			$fixture = $( '#qunit-fixture' );
+		// Load messages for localex
+		i18n.load( {
+			x: 'title X',
+			y: 'custom Y'
+		}, 'localex' );
+		$fixture.data( 'i18n', '[title]x;[custom]y' );
+		assert.strictEqual( $fixture.i18n().attr( 'title' ), 'title X', 'Content of first attribute localized' );
+		assert.strictEqual( $fixture.i18n().attr( 'custom' ), 'custom Y', 'Content of second attribute localized' );
+	} );
+
 	QUnit.module( 'jquery.i18n', {
 		beforeEach: function () {
 			$.i18n( {


### PR DESCRIPTION
Just adding support to multiple attribute replacements on the same element.

For instance:

`<div id="divChkEnable" data-on="enabled products" data-off="disabled products" data-i18n="[data-on]data-on-messagekey;[data-off]data-off-messagekey">`

Best,