### PR TITLE
Add fallbacks for Kashmiri (ks)

### DIFF
--- a/src/jquery.i18n.fallbacks.js
+++ b/src/jquery.i18n.fallbacks.js
@@ -148,7 +148,7 @@
 		koi: [ 'ru' ],
 		krc: [ 'ru' ],
 		krl: [ 'fi' ],
-		ks: [ 'ks-arab' ],
+		ks: [ 'ur', 'hi' ],
 		ksh: [ 'de' ],
 		ksw: [ 'my' ],
 		ku: [ 'ku-latn' ],


### PR DESCRIPTION
This PR is about adding `ur` and `hi` as fallbacks for Kashmiri language. 

Related patches open in Gerrit:
* https://gerrit.wikimedia.org/r/c/mediawiki/core/+/948987
* https://gerrit.wikimedia.org/r/c/translatewiki/+/948712

Bug: 
* https://phabricator.wikimedia.org/T314476