### PR TITLE
Update version to 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wikimedia/jquery.i18n",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wikimedia/jquery.i18n",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "(MIT OR GPL-2.0-or-later)",
       "devDependencies": {
         "eslint-config-wikimedia": "0.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jquery.i18n",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "jQuery based internationalization library",
   "homepage": "https://github.com/wikimedia/jquery.i18n",
   "keywords": [


### PR DESCRIPTION
Updating to update language fallback chains.

This would allow us to update the updated language fallback chains to `mediawiki/core` .

Bug: #281
Change-Id: I0dec600c2bdabcf9d2260e31a8407cbb4df197ae