### PR TITLE
Re-add French (fr) as fallback for Hunde (hke)

### DIFF
--- a/src/jquery.i18n.fallbacks.js
+++ b/src/jquery.i18n.fallbacks.js
@@ -122,6 +122,7 @@
 		guc: [ 'es' ],
 		hak: [ 'zh-hant', 'zh', 'zh-hans' ],
 		hif: [ 'hif-latn' ],
+		hke: [ 'fr' ],
 		hrx: [ 'de' ],
 		hsb: [ 'dsb', 'de' ],
 		hsn: [ 'zh-hant', 'zh', 'zh-hans' ],


### PR DESCRIPTION
Was accidentally removed, caused by fallback added in jquery.i18n before added in mediawiki/core:

Dowstream task:
https://phabricator.wikimedia.org/T379137

Bug: #292
Bug: #296
Bug: T379137
Change-Id: I0be4523c11ee4ae6e7c53ae62000ee37e35d0ed5