### PR TITLE
Add Spanish (es) as fallback for Yucatec Maya (yua)

### DIFF
--- a/src/jquery.i18n.fallbacks.js
+++ b/src/jquery.i18n.fallbacks.js
@@ -316,6 +316,7 @@
 		xal: [ 'ru' ],
 		xmf: [ 'ka' ],
 		yi: [ 'he' ],
+		yua: [ 'es' ],
 		yue: [ 'yue-hant', 'yue-hans' ],
 		'yue-hans': [ 'yue', 'yue-hant' ],
 		'yue-hant': [ 'yue', 'yue-hans' ],


### PR DESCRIPTION
Bug: [T395223](https://phabricator.wikimedia.org/T395223)