### PR TITLE
Revert "Add Spanish (es) as fallback for Yucatec Maya (yua)"

### DIFF
--- a/src/jquery.i18n.fallbacks.js
+++ b/src/jquery.i18n.fallbacks.js
@@ -316,7 +316,6 @@
 		xal: [ 'ru' ],
 		xmf: [ 'ka' ],
 		yi: [ 'he' ],
-		yua: [ 'es' ],
 		yue: [ 'yue-hant', 'yue-hans' ],
 		'yue-hans': [ 'yue', 'yue-hant' ],
 		'yue-hant': [ 'yue', 'yue-hans' ],


### PR DESCRIPTION
Reverts wikimedia/jquery.i18n#301