### PR TITLE
Fixed shared message object reference across locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,6 @@ Example qqq.json:
 ```
 
 In MediaWiki and its hundreds of extensions, message documentation is a strictly followed practice. There is a grunt task to check whether all messages are documented or not. See https://www.npmjs.org/package/grunt-banana-checker
-
+This is my first contribution.
 [npm]: https://img.shields.io/npm/v/@wikimedia/jquery.i18n.svg
 [npm-url]: https://npmjs.com/package/@wikimedia/jquery.i18n

--- a/src/jquery.i18n.messagestore.js
+++ b/src/jquery.i18n.messagestore.js
@@ -100,13 +100,15 @@
 		 * @param {string} locale
 		 * @param {Object} messages
 		 */
-		set: function ( locale, messages ) {
-			if ( !this.messages[ locale ] ) {
-				this.messages[ locale ] = messages;
-			} else {
-				this.messages[ locale ] = $.extend( this.messages[ locale ], messages );
-			}
-		},
+	      set: function ( locale, messages ) {
+	var clonedMessages = $.extend( true, {}, messages );
+
+	if ( !this.messages[ locale ] ) {
+		this.messages[ locale ] = clonedMessages;
+	} else {
+		this.messages[ locale ] = $.extend( true, {}, this.messages[ locale ], clonedMessages );
+	}
+},
 
 		/**
 		 *

--- a/src/jquery.i18n.messagestore.js
+++ b/src/jquery.i18n.messagestore.js
@@ -100,7 +100,7 @@
 		 * @param {string} locale
 		 * @param {Object} messages
 		 */
-	      set: function ( locale, messages ) {
+	 set: function ( locale, messages ) {
 	var clonedMessages = $.extend( true, {}, messages );
 
 	if ( !this.messages[ locale ] ) {


### PR DESCRIPTION
### What I changed

Updated the message store so locale messages are copied before being stored or merged.

### Why

Issue #223 happens when the same object is loaded for multiple locales. Because the object reference is shared, later updates can overwrite values across languages.



Each locale now keeps an independent message object, so loading additional messages no longer causes all languages to become the same.

Fixes #223
