### PR TITLE
Add GitHub repository link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 jQuery.i18n
 ===========
 
+**GitHub Repository:** https://github.com/wikimedia/jquery.i18n
+
 [![npm][npm]][npm-url]
 
 > NOTE: For jquery independent version of this library, see https://github.com/wikimedia/banana-i18n


### PR DESCRIPTION
## Issue
Issue #309: Beginners cannot find a direct link to the GitHub repository

## Solution
Added a prominent GitHub repository link at the top of the README so beginners can easily access the source code.

## Changes
- Added GitHub repository URL link in the README header section

## Fixes #309